### PR TITLE
[API gateways] Get authentication type options from backend

### DIFF
--- a/pkg/dashboard/ui/src/app/app.run.js
+++ b/pkg/dashboard/ui/src/app/app.run.js
@@ -26,6 +26,7 @@
                 NuclioProjectsDataService.getFrontendSpec()
                     .then(function (response) {
                         lodash.assign(ConfigService.nuclio, {
+                            allowedAuthenticationModes: lodash.get(response, 'allowedAuthenticationModes', []),
                             defaultFunctionConfig: lodash.get(response, 'defaultFunctionConfig', {}),
                             externalIPAddress: lodash.get(response, 'externalIPAddresses[0]', ''),
                             imageNamePrefixTemplate: lodash.get(response, 'imageNamePrefixTemplate', ''),


### PR DESCRIPTION
https://trello.com/c/tf8RTj9r/616-api-gateways-get-authentication-type-options-from-backend